### PR TITLE
Adding a docker based development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+
+# A vscode remote container docker image with conda from
+# https://hub.docker.com/_/microsoft-vscode-devcontainers
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
+
+RUN conda install -c conda-forge mamba
+
+# specifying dagmc version so all the examples work and no mpi to reduce complexity
+RUN mamba install -c conda-forge -y "openmc=0.13.0=dagmc*nompi*"
+
+# Jupyter lab installed to run examples
+RUN mamba install -c conda-forge jupyterlab
+
+# downloads ENDF/B-VII.1 from https://openmc.org/official-data-libraries/
+RUN wget https://anl.box.com/shared/static/9igk353zpy8fn9ttvtrqgzvw1vtejoz6.xz
+
+# extracts the nuclear data
+RUN tar -xf 9igk353zpy8fn9ttvtrqgzvw1vtejoz6.xz
+
+ENV OPENMC_CROSS_SECTIONS=/endfb71_hdf5/cross_sections.xml

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			"VARIANT": "3.10-bullseye",
+		}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			]
+		}
+	},
+
+	// Allows port 8888 used for Jupyter Notebook to be available locally.
+	"forwardPorts": [8888],
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
As demonstrated at the IAEA open source workshop.

To get this working with prebuilds one would have to enable code spaces on the github org.

When loading up jupyter lab it is necessary to select the correct python interpreter, in this setup it is the conda one
